### PR TITLE
Standardize Claude GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,15 +1,18 @@
 name: Claude
 
-# Canonical Claude GitHub Action workflow. Copy this file verbatim to
-# .github/workflows/claude.yaml in any target repo (or use
-# sync-claude-action.sh install OWNER/REPO).
+# Claude GitHub Action workflow. Synced from a canonical source —
+# re-sync rather than editing in place, or changes will be overwritten.
+#
+# Canonical at https://github.com/chriscalo/dev-skills under:
+#   skills/github/claude-action-workflow.yaml — this file
+#   skills/github/claude-action.md — design + tool policy
+#   skills/github/sync-claude-action.sh — re-sync command
 #
 # Behaves like a helpful human collaborator: fires on every editor-authored
 # event in any thread, then Claude decides whether to respond, reacts with
 # 👀 on comments it engages with, extends or replaces prior work as
 # appropriate, or stays silent. Editor-only at the workflow level — bots
-# and strangers skip entirely. See skills/github/claude-action.md for the
-# full design.
+# and strangers skip entirely.
 
 on:
   issue_comment:
@@ -34,22 +37,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  claude:
+  # Editor-only floor: check the ACTOR's permission on this repo.
+  # Authoritative — asks the GitHub API directly. The `claude` job below
+  # depends on this gate's output, so non-editors (strangers, bots) skip
+  # the workflow entirely with no per-step `if:` repeats.
+  gate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-      actions: read
+    outputs:
+      is-editor: ${{ steps.check.outputs.is-editor }}
     steps:
-      # Editor-only floor: check the ACTOR's permission on this repo.
-      # Authoritative — uses the GitHub API rather than guessing from
-      # author_association (which is the original author's association,
-      # not the actor's, and gives wrong answers for label/edit/unlabel
-      # events where actor != author). All subsequent steps are gated on
-      # this check, so non-editors (strangers, bots) skip cleanly.
-      - id: editor-check
+      - id: check
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -64,12 +61,123 @@ jobs:
             echo "Skipping: $actor has '$perm' permission, not editor"
             echo "is-editor=false" >> "$GITHUB_OUTPUT"
           fi
-      - if: steps.editor-check.outputs.is-editor == 'true'
-        uses: actions/checkout@v6
+  
+  claude:
+    needs: gate
+    if: needs.gate.outputs.is-editor == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - if: steps.editor-check.outputs.is-editor == 'true'
-        uses: anthropics/claude-code-action@v1
+      # Install the `upload-image` helper on PATH so the agent can publish
+      # local images and embed the resulting URL in PR/issue markdown
+      # without ever knowing about R2, AWS, endpoints, or account IDs.
+      # See "Embedding images in GitHub markdown" in the prompt for the
+      # agent-facing contract.
+      #
+      # The R2 secrets are exposed here as STEP-LEVEL env (not job-level),
+      # so the subsequent claude-code-action step — where the agent runs
+      # its bash commands — has no R2_*/AWS_* in its environment. The
+      # install step stashes credentials in a private file (mode 600 in
+      # $RUNNER_TEMP) that the helper sources at call time. Running
+      # `env` inside the agent's session reveals nothing about storage.
+      - name: Install upload-image helper
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        run: |
+          # If all three secrets are set, write a private creds file the
+          # helper sources at call time. `printf %q` shell-quotes values
+          # so secrets with special chars round-trip safely. If any
+          # secret is empty (repo hasn't opted into image uploads), skip
+          # the creds file entirely; the helper will see no file and
+          # exit with a clear "not configured" message.
+          creds_file="$RUNNER_TEMP/.upload-image-creds"
+          if [ -n "${R2_ACCOUNT_ID:-}" ] \
+             && [ -n "${R2_ACCESS_KEY_ID:-}" ] \
+             && [ -n "${R2_SECRET_ACCESS_KEY:-}" ]; then
+            umask 077
+            {
+              printf 'AWS_ACCESS_KEY_ID=%q\n'     "$R2_ACCESS_KEY_ID"
+              printf 'AWS_SECRET_ACCESS_KEY=%q\n' "$R2_SECRET_ACCESS_KEY"
+              printf 'AWS_DEFAULT_REGION=auto\n'
+              printf 'R2_ACCOUNT_ID=%q\n'         "$R2_ACCOUNT_ID"
+            } > "$creds_file"
+            chmod 600 "$creds_file"
+          fi
+
+          mkdir -p "$RUNNER_TEMP/bin"
+          cat > "$RUNNER_TEMP/bin/upload-image" <<'HELPER_EOF'
+          #!/usr/bin/env bash
+          # upload-image — publish a local image and print its public URL.
+          # Usage: upload-image <local-path> [<remote-key>]
+          # If <remote-key> is omitted, generates <repo>/<timestamp>-<basename>.
+          # Exits 0 with URL on stdout, non-zero with reason on stderr.
+          set -euo pipefail
+
+          creds_file="$RUNNER_TEMP/.upload-image-creds"
+          if [ ! -r "$creds_file" ]; then
+            echo "upload-image: not configured on this repo (no R2 secrets)" >&2
+            echo "  fix: run sync-claude-action.sh setup-r2 OWNER/REPO" >&2
+            exit 3
+          fi
+          set -a
+          # shellcheck disable=SC1090
+          source "$creds_file"
+          set +a
+
+          local_path="${1:-}"
+          if [ -z "$local_path" ]; then
+            echo "usage: upload-image <local-path> [<remote-key>]" >&2
+            exit 2
+          fi
+          if [ ! -f "$local_path" ]; then
+            echo "upload-image: file not found: $local_path" >&2
+            exit 2
+          fi
+
+          remote_key="${2:-}"
+          if [ -z "$remote_key" ]; then
+            repo_name="${GITHUB_REPOSITORY##*/}"
+            : "${repo_name:=local}"
+            ts="$(date -u +%Y-%m-%dT%H-%M-%S)"
+            # Sanitize the basename: spaces → dashes, then drop any chars
+            # that aren't URL-safe. Filenames like "Screenshot 2026-05-26
+            # at 14.32.15.png" would otherwise produce a remote key whose
+            # printed URL has literal spaces, breaking the rendered markdown
+            # link. An explicit second-arg <remote-key> is taken as-is.
+            base="$(basename "$local_path" | tr ' ' '-' | tr -cd 'A-Za-z0-9._-')"
+            if [ -z "$base" ]; then base=image; fi
+            remote_key="$repo_name/$ts-$base"
+          fi
+
+          ext="${local_path##*.}"
+          case "${ext,,}" in
+            png)      content_type=image/png ;;
+            jpg|jpeg) content_type=image/jpeg ;;
+            gif)      content_type=image/gif ;;
+            webp)     content_type=image/webp ;;
+            svg)      content_type=image/svg+xml ;;
+            *)        content_type=application/octet-stream ;;
+          esac
+
+          aws s3 cp "$local_path" "s3://img/$remote_key" \
+            --endpoint-url "https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com" \
+            --content-type "$content_type" \
+            >/dev/null
+          echo "https://img.chriscalo.com/$remote_key"
+          HELPER_EOF
+          chmod +x "$RUNNER_TEMP/bin/upload-image"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -174,8 +282,27 @@ jobs:
             With the workflow's concurrency block, runs for the same issue
             are serialized — but per-run branch names are still cheap
             insurance against any edge case.
+            ### Embedding images in GitHub markdown
+            GitHub's web UI lets users paste images into comments, but
+            that upload endpoint isn't reachable from CI. To embed an
+            image anywhere GitHub renders markdown (PR comments, issue
+            comments, PR descriptions, etc.), run the `upload-image`
+            helper already on PATH:
+            ```sh
+            url=$(upload-image path/to/local.png)
+            ```
+            Then embed the URL with standard markdown:
+            `![alt text]($url)`. The helper handles everything — storage,
+            content-type, naming, public URL construction — and prints
+            only the URL on stdout when it succeeds. You don't need to
+            know or set any storage credentials.
+            If `upload-image` exits non-zero with "not configured on this
+            repo", image hosting isn't set up here — post your reply
+            without the image (or describe what it would have shown).
+            For any other non-zero exit, surface the stderr so the human
+            can fix the configuration.
           claude_args: >-
-            --allowedTools "Read,Edit,Write,Grep,Glob,Bash(*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Skill,Task,Agent,Bash(*),WebFetch,WebSearch"
             --disallowedTools
             "Bash(rm -rf /),Bash(git push --force*),Bash(git push -*f*),Bash(git
             push * --force*),Bash(git push * -*f*),Bash(git branch -*d
@@ -187,4 +314,7 @@ jobs:
             delete*),Bash(gh secret remove*),Bash(gh auth logout*),Bash(git
             push origin main*),Bash(git push origin HEAD:main*),Bash(git push
             * main*),Bash(git push * HEAD:main*),Bash(git push origin
-            main:*),Bash(git push * main:*)"
+            main:*),Bash(git push * main:*),Bash(git push origin
+            +*),Bash(git push * +*),Bash(git push origin :*),Bash(git push
+            * :*),Bash(git push origin --delete*),Bash(git push *
+            --delete*)"


### PR DESCRIPTION
Adds (or replaces) `.github/workflows/claude.yaml` with the
canonical workflow from
[chriscalo/dev-skills](https://github.com/chriscalo/dev-skills/blob/main/skills/github/claude-action-workflow.yaml).

**Tool policy**: `--allowedTools "Read,Grep,Glob,Edit,Write,Skill,Task,Agent,Bash(*),WebFetch,WebSearch"`
with a targeted `--disallowedTools` list. See
[claude-action.md "Tool policy"](https://github.com/chriscalo/dev-skills/blob/main/skills/github/claude-action.md#tool-policy)
for rationale.

Future drift can be detected via
`sync-claude-action.sh audit OWNER/REPO`.